### PR TITLE
Use the same retry logic from stargazers for issues.

### DIFF
--- a/repohealth/github/issues.py
+++ b/repohealth/github/issues.py
@@ -48,10 +48,38 @@ def repo_issues(repo, token):
         url = ("{}?per_page={}&page={}&state=all"
                "".format(issues_url, page_size, page))
         f = client.fetch(url, headers=headers, callback=get_issues)
+        f.url = url
         futures.append(f)
 
-    for future in futures:
-        yield future
+    while futures:
+        waited = False
+        for future in futures[:]:
+            future = futures.pop(0)
+            try:
+                yield future
+            except tornado.httpclient.HTTPError as err:
+                # Try again, but give it a little while...
+                url = future.url
+                if error_count < 5:
+                    f = client.fetch(future.url, headers=headers,
+                                     callback=get_issues)
+                    f.url = future.url
+                    futures.append(f)
+                else:
+                    if not waited:
+                        # Give Github some time to get over our request
+                        # before we retry.
+                        logging.exception("Sleeping attempt {} to rectify "
+                                          "fetch error.".format(error_count))
+                        yield tornado.gen.sleep(15)
+                        error_count += 1
+                        waited = True
+
+                    logging.exception('A problem with {} occured after {} '
+                                      'attempts. Skipping'
+                                      ''.format(url, error_count))
+                    logging.exception(traceback.format_exc())
+
     return issues
 
 


### PR DESCRIPTION
Will hopefully close #11. Wasn't able to reliably reproduce locally (because it is GitHub that is raising the 403 when we hit it too often).

Ping @asmeurer.